### PR TITLE
Snort sensor deployed on CentOS 7 

### DIFF
--- a/scripts/deploy_snort.sh
+++ b/scripts/deploy_snort.sh
@@ -19,9 +19,34 @@ wget $server_url/static/registration.txt -O registration.sh
 chmod 755 registration.sh
 # Note: this will export the HPF_* variables
 . ./registration.sh $server_url $deploy_key "snort"
- 
-apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential libpcap-dev libjansson-dev libpcre3-dev libdnet-dev libdumbnet-dev libdaq-dev flex bison python-pip git make automake libtool zlib1g-dev
+
+# 
+cron_path="/etc/cron.daily/update_snort_rules.sh"
+
+# linux distro detection module:
+
+if [ -f /etc/lsb-release ]; then linux_version="Ubuntu";
+    supervisor_conf_path="/etc/supervisor/conf.d/snort.conf";
+elif [ -f /etc/os-release ]; then linux_version="CentOS";
+    supervisor_conf_path="/etc/supervisord.d/snort.conf";
+<<EOF
+elif [ -f /etc/debian-version ]; then linux_version="Debian";
+    supervisor_conf_path="";
+    cron_path=""
+elif [ -f /etc/redhat-release ]; then linux_version="RedHat";
+    supervisor_conf_path="";
+    cron_path=""
+EOF
+fi
+
+if [ "$linux_version" == "Ubuntu" ]; then apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential libpcap-dev libjansson-dev libpcre3-dev libdnet-dev libdumbnet-dev libdaq-dev flex bison python-pip git make automake libtool zlib1g-dev supervisor
+
+elif [ "$linux_version" == "CentOS" ]; then yum -y groupinstall 'Development Tools'
+yum -y install python-pip zlib-devel libdnet-devel libpcap-devel jansson-devel pcre-devel supervisor
+wget https://www.snort.org/downloads/snort/daq-2.0.4.centos7.x86_64.rpm
+yum -y localinstall daq-2.0.4.centos7.x86_64.rpm
+fi
 
 pip install --upgrade distribute
 pip install virtualenv
@@ -69,8 +94,11 @@ sed -i 's,# include $RULE_PATH/local.rules,include $RULE_PATH/local.rules,' snor
 # enable hpfeeds
 sed -i "s/# hpfeeds/# hpfeeds\noutput log_hpfeeds: host $HPF_HOST, ident $HPF_IDENT, secret $HPF_SECRET, channel snort.alerts, port $HPF_PORT/" snort.conf 
 
-
+if [ "$linux_version" == "Ubuntu" ]; then 
 IP=$(ifconfig $INTERFACE | grep 'inet addr' | cut -f2 -d: | awk '{print $1}')
+elif [ "$linux_version" == "CentOS" ]; then 
+IP=$(ifconfig $INTERFACE | grep 'inet' | cut -f2 -d: | awk '{print $2}')
+fi
 sed -i "s/ipvar HOME_NET any/ipvar HOME_NET $IP/" snort.conf
 
 # Installing snort rules.
@@ -78,11 +106,9 @@ sed -i "s/ipvar HOME_NET any/ipvar HOME_NET $IP/" snort.conf
 rm -f /etc/snort/rules/local.rules
 ln -s /opt/mhn/rules/mhn.rules /opt/snort/rules/local.rules
 
-# Supervisor will manage snort-hpfeeds
-apt-get install -y supervisor
-
-# Config for supervisor.
-cat > /etc/supervisor/conf.d/snort.conf <<EOF
+# Config for supervisor separately for different distro:
+# supervisord.d
+cat > "$supervisor_conf_path" <<EOF
 [program:snort]
 command=/opt/snort/bin/snort -c /opt/snort/etc/snort.conf -i $INTERFACE
 directory=/opt/snort
@@ -94,7 +120,7 @@ redirect_stderr=true
 stopsignal=QUIT
 EOF
 
-cat > /etc/cron.daily/update_snort_rules.sh <<EOF
+cat > "$cron_path" <<EOF
 #!/bin/bash
 
 mkdir -p /opt/mhn/rules

--- a/server/mhn/static/registration.txt
+++ b/server/mhn/static/registration.txt
@@ -12,7 +12,8 @@ deploy_key=$2
 honeypot=$3
 hostname=$(hostname)
 
-sudo apt-get install -y curl
+if [ -f /etc/lsb-release ]; then sudo apt-get install -y curl
+fi
 
 curl -s -X POST -H "Content-Type: application/json" -d "{
 	\"name\": \"${hostname}-${honeypot}\", 


### PR DESCRIPTION
Tested at CentOS 7 and Ubuntu 12.04 both. Works fine.
Supervisor have a significant bug related with sockets on CentOS 7, it was unable to launch it to me. Perhaps it might be best to exclude it out from sensor's software as unnecessary one.