### PR TITLE
change the geoip to be looked up locally 

### DIFF
--- a/scripts/install_mhnserver.sh
+++ b/scripts/install_mhnserver.sh
@@ -7,6 +7,10 @@ apt-get update
 apt-get install -y git build-essential python-pip python-dev redis-server
 pip install virtualenv
 
+cd /opt
+wget http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz &&gzip -d GeoLite2-City.mmdb.gz
+cd -
+
 MHN_HOME=`dirname $0`/..
 cd $MHN_HOME
 MHN_HOME=`pwd`

--- a/server/mhn/ui/utils.py
+++ b/server/mhn/ui/utils.py
@@ -6,6 +6,7 @@ import os
 from werkzeug.contrib.cache import SimpleCache
 import socket
 import struct
+import maxminddb
 from mhn.api.models import Sensor
 
 flag_cache = SimpleCache(threshold=1000, default_timeout=300)
@@ -58,12 +59,12 @@ def _get_flag_ip(ipaddr):
     Defaults to static immge: '/static/img/unknown.png'
     """
     flag_path = '/static/img/flags-iso/shiny/64/{}.png'
-    geo_api = 'https://geospray.threatstream.com/ip/{}'
     try:
         # Using threatstream's geospray API to get
         # the country code for this IP address.
-        r = requests.get(geo_api.format(ipaddr))
-        ccode = r.json()['countryCode']
+      
+        r= maxminddb.open_database('/opt/GeoLite2-City.mmdb')
+        ccode = str(r.get(ipaddr)['country']['iso_code'])
     except Exception:
         app.logger.warning("Could not determine flag for ip: {}".format(ipaddr))
         return constants.DEFAULT_FLAG_URL

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -16,3 +16,4 @@ uwsgi
 pymongo
 -e git+https://github.com/threatstream/hpfeeds/#egg=hpfeeds-dev
 pygal==1.7.0
+maxminddb==1.1.1


### PR DESCRIPTION
I believe that it will be better to look up the geoip locally instead of accessing threatstream API
because 
- maybe you don't want you mhn server to access external resources 
- with all respect, the database at threatstream is not updated which cause some flags to fail to show
- it will be faster

Thanks
