### PR TITLE
support for JSON Payload in hpfeed collection; Payload performance; Dashboard Additions

### DIFF
--- a/server/mhn/common/clio.py
+++ b/server/mhn/common/clio.py
@@ -387,7 +387,13 @@ class HpFeed(ResourceMixin):
     channel_map = {'snort.alerts':['date', 'sensor', 'source_ip', 'destination_port', 'priority', 'classification', 'signature'],
                    'dionaea.capture':['url', 'daddr', 'saddr', 'dport', 'sport', 'sha512', 'md5'],
                    'glastopf.events':['time', 'pattern', 'filename', 'source', 'request_url']}
-
+    def json_payload(self, data):
+        if type(data) is dict:
+             o_data = data
+        else:
+             o_data = json.loads(data)
+        return o_data
+        
     def get_payloads(self, options, req_args):
         payloads = []
         columns = []
@@ -401,12 +407,7 @@ class HpFeed(ResourceMixin):
 
         feed_rows = self.get(options=options, **req_args)
         for row in feed_rows:
-            try:
-                payload = json.loads(row.payload)
-            except:
-                pass
-            payloads.append(payload)
-
+            payloads.append(self.json_payload(row.payload))
         return count,columns,payloads
 
 
@@ -444,7 +445,7 @@ class HpFeed(ResourceMixin):
             query['hours_ago'] = hours_ago
 
         res = self.get(options={}, **query)
-        val_list = [rec.get(field) for rec in [json.loads(r.payload) for r in res] if field in rec]
+        val_list = [rec.get(field) for rec in [self.json_payload(r.payload) for r in res] if field in rec]
         cnt = Counter()
         for val in val_list:
             cnt[val] += 1

--- a/server/mhn/common/clio.py
+++ b/server/mhn/common/clio.py
@@ -318,6 +318,12 @@ class Session(ResourceMixin):
     def top_targeted_ports(self, top=5, hours_ago=None):
         return self._tops('destination_port', top, hours_ago)
 
+    def top_hp(self, top=5, hours_ago=None):
+        return self._tops('honeypot', top, hours_ago)
+    
+    def top_sensor(self, top=5, hours_ago=None):
+        return self._tops('identifier', top, hours_ago)
+    
     def attacker_stats(self, ip, hours_ago=None):
         match_query = { 'source_ip': ip }
 
@@ -397,7 +403,7 @@ class HpFeed(ResourceMixin):
     def get_payloads(self, options, req_args):
         payloads = []
         columns = []
-        if 'payload' in req_args:
+        if len(req_args.get('payload','')) > 1:
             req_args['payload'] = {'$regex':req_args['payload']}
 
         cnt_query = super(HpFeed, self)._clean_query(req_args)
@@ -405,10 +411,7 @@ class HpFeed(ResourceMixin):
 
         columns = self.channel_map.get(req_args['channel'])
 
-        feed_rows = self.get(options=options, **req_args)
-        for row in feed_rows:
-            payloads.append(self.json_payload(row.payload))
-        return count,columns,payloads
+        return count,columns,(self.json_payload(fr.payload) for fr in self.get(options=options, **req_args))
 
 
     def count_passwords(self,payloads):

--- a/server/mhn/templates/ui/dashboard.html
+++ b/server/mhn/templates/ui/dashboard.html
@@ -53,6 +53,38 @@
         </div>
         <div class="row" style="margin-top:30px;">
             <div class="small-6 columns">
+                <h3>TOP 5 Honey Pots:</h3>
+            </div>
+        </div>
+        <div class="row">
+            <div class="small-10 push-2 columns">
+                <ol>
+                {% for hp in top_hp %}
+                    <li><strong>
+                    <a href="{{ url_for('ui.get_attacks', honeypot=hp.honeypot) }}">{{ hp.honeypot }} ({{ hp.count | number_format }} attacks)</a>
+                    </li></strong>
+                {% endfor %}
+                </ol>
+            </div>
+        </div>
+        <div class="row" style="margin-top:30px;">
+            <div class="small-6 columns">
+                <h3>TOP 5 Sensors:</h3>
+            </div>
+        </div>
+        <div class="row">
+            <div class="small-10 push-2 columns">
+                <ol>
+                {% for s in top_sensor %}
+                    <li><strong>
+                    <a href="{{ url_for('ui.get_attacks', identifier=s.identifier) }}">{{ get_sensor_name(s.identifier) }} ({{ s.count | number_format }} attacks)</a>
+                    </li></strong>
+                {% endfor %}
+                </ol>
+            </div>
+        </div>
+        <div class="row" style="margin-top:30px;">
+            <div class="small-6 columns">
                 <h3>TOP 5 Attacks Signatures:</h3>
             </div>
         </div>

--- a/server/mhn/ui/views.py
+++ b/server/mhn/ui/views.py
@@ -62,14 +62,21 @@ def dashboard():
     top_attackers = clio.session.top_attackers(top=5, hours_ago=24)
     # TOP 5 attacked ports
     top_ports = clio.session.top_targeted_ports(top=5, hours_ago=24)
+    #Top 5 honey pots with counts
+    top_hp = clio.session.top_hp(top=5, hours_ago=24)
+    #Top Honeypot sensors
+    top_sensor = clio.session.top_sensor(top=5, hours_ago=24)
     # TOP 5 sigs
     freq_sigs = clio.hpfeed.top_sigs(top=5, hours_ago=24)
-
+    
     return render_template('ui/dashboard.html',
                            attackcount=attackcount,
                            top_attackers=top_attackers,
                            top_ports=top_ports,
+                           top_hp=top_hp,
+                           top_sensor=top_sensor,
                            freq_sigs=freq_sigs,
+                           get_sensor_name=get_sensor_name,
                            get_flag_ip=get_flag_ip)
 
 


### PR DESCRIPTION
This adds in support for the switch I'm proposing in mnemosyne for payload from string to JSON object in clio.py. Also noticed in get_payloads I was passing a list from the generator returned by the ResourceMixin, changed that to pass a generator on. 

Decided to add stats for Top Sensors and Top Honey Pots to the Dashboard. Helpful for me at least. 