### PR TITLE
Changed Kippo deploy script to be compatible with boh Ubuntu and Raspberry Pi

### DIFF
--- a/scripts/deploy_kippo.sh
+++ b/scripts/deploy_kippo.sh
@@ -24,7 +24,7 @@ apt-get -y install python-dev openssl python-openssl python-pyasn1 python-twiste
 
 # Change real SSH Port to 2222
 sed -i 's/Port 22$/Port 2222/g' /etc/ssh/sshd_config
-reload ssh
+service ssh restart
 
 # Create Kippo user
 useradd -d /home/kippo -s /bin/bash -m kippo -g users

--- a/server/mhn/__init__.py
+++ b/server/mhn/__init__.py
@@ -140,7 +140,7 @@ def create_clean_db():
             'Ubuntu - Conpot': path.abspath('../scripts/deploy_conpot.sh'),
             'Ubuntu - Dionaea': path.abspath('../scripts/deploy_dionaea.sh'),
             'Ubuntu - Snort': path.abspath('../scripts/deploy_snort.sh'),
-            'Ubuntu - Kippo': path.abspath('../scripts/deploy_kippo.sh'),
+            'Ubuntu/Raspberry Pi - Kippo': path.abspath('../scripts/deploy_kippo.sh'),
             'Ubuntu - Amun': path.abspath('../scripts/deploy_amun.sh'),
             'Ubuntu - Glastopf': path.abspath('../scripts/deploy_glastopf.sh'),
             'Ubuntu - Wordpot': path.abspath('../scripts/deploy_wordpot.sh'),


### PR DESCRIPTION
The change is to replace "reload ssh" with "service ssh restart". The latter
works on both systems. It does not interrupt any open sessions.

This solves the same issue as https://github.com/threatstream/mhn/pull/133 but in a slightly different way.