### PR TITLE
Improved randomness in email reset hash

### DIFF
--- a/server/mhn/auth/views.py
+++ b/server/mhn/auth/views.py
@@ -1,5 +1,5 @@
 import hashlib
-from datetime import datetime
+import random
 
 from flask import Blueprint, request, jsonify
 from flask.ext.mail import Message
@@ -95,7 +95,7 @@ def reset_passwd_request():
     user = User.query.filter_by(email=email).first()
     if not user:
         return error_response(errors.AUTH_NOT_FOUND.format(email), 404)
-    hashstr = hashlib.sha1(str(datetime.utcnow()) + user.email).hexdigest()
+    hashstr = hashlib.sha1(str(random.getrandbits(128)) + user.email).hexdigest()
     # Deactivate all other password resets for this user.
     PasswdReset.query.filter_by(user=user).update({'active': False})
     reset = PasswdReset(hashstr=hashstr, active=True, user=user)


### PR DESCRIPTION
Replaced time based hash salt with random based hash salt. Preventing an unauthorized user with a known email address from triggering a password reset then guessing the milliseconds via brute force. While it took a little while against my own system as a poc, this style of attack did work in a reasonable amount of time.