### PR TITLE
PATH updated in install scripts for Centos 6.7

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ SCRIPTS="$MHN_HOME/scripts/"
 cd $SCRIPTS
 
 if [ -f /etc/redhat-release ]; then
-    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:$PATH
     ./install_sqlite.sh
 
     if [ ! -f /usr/local/bin/python2.7 ]; then

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ SCRIPTS="$MHN_HOME/scripts/"
 cd $SCRIPTS
 
 if [ -f /etc/redhat-release ]; then
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
     ./install_sqlite.sh
 
     if [ ! -f /usr/local/bin/python2.7 ]; then

--- a/scripts/deploy_dionaea.sh
+++ b/scripts/deploy_dionaea.sh
@@ -19,6 +19,7 @@ chmod 755 registration.sh
 . ./registration.sh $server_url $deploy_key "dionaea"
 
 if [ -f /etc/redhat-release ]; then
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
     yum -y update
     yum -y install wget curl epel-release python-setuptools python-pip
     easy_install supervisor

--- a/scripts/deploy_dionaea.sh
+++ b/scripts/deploy_dionaea.sh
@@ -19,7 +19,7 @@ chmod 755 registration.sh
 . ./registration.sh $server_url $deploy_key "dionaea"
 
 if [ -f /etc/redhat-release ]; then
-    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:$PATH
     yum -y update
     yum -y install wget curl epel-release python-setuptools python-pip
     easy_install supervisor

--- a/scripts/install_honeymap.sh
+++ b/scripts/install_honeymap.sh
@@ -12,7 +12,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
-    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:$PATH
     yum update -y
     yum install -y  git mercurial make coffee-script.noarch geoip-devel
 

--- a/scripts/install_honeymap.sh
+++ b/scripts/install_honeymap.sh
@@ -12,6 +12,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
     yum update -y
     yum install -y  git mercurial make coffee-script.noarch geoip-devel
 

--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -17,7 +17,7 @@ if [ -f /etc/debian_version ]; then
     VIRTUALENV=`which virtualenv`
 
 elif [ -f /etc/redhat-release ]; then
-    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:$PATH
     yum install -y yum-utils
     yum-config-manager --add-repo=https://copr.fedoraproject.org/coprs/librehat/shadowsocks/repo/epel-6/librehat-shadowsocks-epel-6.repo
     yum update -y

--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -17,6 +17,7 @@ if [ -f /etc/debian_version ]; then
     VIRTUALENV=`which virtualenv`
 
 elif [ -f /etc/redhat-release ]; then
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
     yum install -y yum-utils
     yum-config-manager --add-repo=https://copr.fedoraproject.org/coprs/librehat/shadowsocks/repo/epel-6/librehat-shadowsocks-epel-6.repo
     yum update -y

--- a/scripts/install_mhnserver.sh
+++ b/scripts/install_mhnserver.sh
@@ -17,6 +17,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
     INSTALLER='yum'
     REPOPACKAGES='epel-release git GeoIP-devel wget redis nginx'
 

--- a/scripts/install_mhnserver.sh
+++ b/scripts/install_mhnserver.sh
@@ -17,7 +17,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
-    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:$PATH
     INSTALLER='yum'
     REPOPACKAGES='epel-release git GeoIP-devel wget redis nginx'
 

--- a/scripts/install_mnemosyne.sh
+++ b/scripts/install_mnemosyne.sh
@@ -23,7 +23,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
-
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
     if  [ ! -f /usr/local/bin/python2.7 ]; then
         $SCRIPTDIR/install_python2.7.sh
     fi

--- a/scripts/install_mnemosyne.sh
+++ b/scripts/install_mnemosyne.sh
@@ -23,7 +23,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
-    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:$PATH
     if  [ ! -f /usr/local/bin/python2.7 ]; then
         $SCRIPTDIR/install_python2.7.sh
     fi

--- a/scripts/install_mongo.sh
+++ b/scripts/install_mongo.sh
@@ -11,7 +11,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
-    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:$PATH
 
 cat >> /etc/yum.repos.d/mongodb.repo <<EOF
 [mongodb-org]

--- a/scripts/install_mongo.sh
+++ b/scripts/install_mongo.sh
@@ -11,6 +11,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 cat >> /etc/yum.repos.d/mongodb.repo <<EOF
 [mongodb-org]

--- a/scripts/install_python2.7.sh
+++ b/scripts/install_python2.7.sh
@@ -12,7 +12,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
-    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:$PATH
     yum -y update
     yum -y groupinstall "Development tools"
     yum -y install openssl-devel

--- a/scripts/install_python2.7.sh
+++ b/scripts/install_python2.7.sh
@@ -12,7 +12,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
-
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
     yum -y update
     yum -y groupinstall "Development tools"
     yum -y install openssl-devel

--- a/scripts/install_sqlite.sh
+++ b/scripts/install_sqlite.sh
@@ -13,6 +13,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
     yum -y update
     yum -y install epel-release wget
     yum -y groupinstall "Development tools"

--- a/scripts/install_sqlite.sh
+++ b/scripts/install_sqlite.sh
@@ -13,7 +13,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
-    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:$PATH
     yum -y update
     yum -y install epel-release wget
     yum -y groupinstall "Development tools"

--- a/scripts/install_supervisord.sh
+++ b/scripts/install_supervisord.sh
@@ -12,7 +12,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
-    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:$PATH
     #install python2.7 if it isn't installed
     if  [ ! -f /usr/local/bin/python2.7 ]; then
         $SCRIPTDIR/install_python2.7.sh

--- a/scripts/install_supervisord.sh
+++ b/scripts/install_supervisord.sh
@@ -12,7 +12,7 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/redhat-release ]; then
     OS=RHEL
-
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
     #install python2.7 if it isn't installed
     if  [ ! -f /usr/local/bin/python2.7 ]; then
         $SCRIPTDIR/install_python2.7.sh


### PR DESCRIPTION
Some versions of Centos 6.7 have installation problems related to $PATH not including necessary directories. To fix this issue, I defined $PATH at the start of the RHEL section the default in my VM. 
