### PR TITLE
Fixed Wordpot Deploy Script

### DIFF
--- a/scripts/deploy_wordpot.sh
+++ b/scripts/deploy_wordpot.sh
@@ -56,9 +56,9 @@ stopsignal=QUIT
 EOF
 
 # Quick check to see if on Ubuntu using systemd or init
-if [ -n `which service` ]; then
+if [ -n "`which service`" ]; then
     service supervisor start
-elif [ -n `which systemctl` ]; then
+elif [ -n "`which systemctl`" ]; then
     systemctl start supervisor
 fi
 

--- a/scripts/deploy_wordpot.sh
+++ b/scripts/deploy_wordpot.sh
@@ -55,4 +55,11 @@ redirect_stderr=true
 stopsignal=QUIT
 EOF
 
+# Quick check to see if on Ubuntu using systemd or init
+if [ -n `which service` ]; then
+    service supervisor start
+elif [ -n `which systemctl` ]; then
+    systemctl start supervisor
+fi
+
 supervisorctl update


### PR DESCRIPTION
Fixes error on Ubuntu 14.04 when deploying wordpot. Error below:

+ supervisorctl update
error: <class 'socket.error'>, [Errno 2] No such file or directory: file: /usr/lib/python2.7/socket.py line: 224

The fix is to start supervisorctl (which is not started automatically when deploying wordpot).