### PR TITLE
Updated uWSGI to version 2.0.14 for Ubuntu 16.04.1 compatibility.

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -13,7 +13,7 @@ celery==3.1.16
 redis==2.10.3
 requests==2.4.3
 xmltodict==0.9.0
-uWSGI==2.0.8
+uWSGI==2.0.14
 pymongo==2.7.2
 hpfeeds-threatstream==1.0
 pygal==1.7.0


### PR DESCRIPTION
Was unable to install (after getting the MongoDB issues sorted) and had to adjust this to get it to build.