### PR TITLE
Updated fetch-emerging-rules cron time

### DIFF
--- a/server/config.py.template
+++ b/server/config.py.template
@@ -42,7 +42,7 @@ RENDERED_RULES_PATH = os.path.join(_basedir, 'mhn/static/mhn.rules')
 CELERYBEAT_SCHEDULE = {
     'fetch-emerging-rules': {
             'task': 'mhn.tasks.rules.fetch_sources',
-            'schedule': crontab(hour=12),
+            'schedule': crontab(minute=0, hour=12),
             'args': ()
     }
 }


### PR DESCRIPTION
Change cron to be once in the 12th hour from every minute   
 >>> crontab(minute=0, hour=12)
<crontab: 0 12 * * * (m/h/d/dM/MY)>
>>> crontab(hour=12)
<crontab: * 12 * * * (m/h/d/dM/MY)>
>>>