### PR TITLE
derive server base_url before passing to honeymap url

### DIFF
--- a/server/generateconfig.py
+++ b/server/generateconfig.py
@@ -125,7 +125,9 @@ def generate_config():
         if server_base_url.endswith('/'):
             server_base_url = server_base_url[:-1]
 
-        default_honeymap_url = '{}:3000'.format(server_base_url)
+        server_base_url = server_base_url if server_base_url.strip() else default_base_url
+
+	default_honeymap_url = '{}:3000'.format(server_base_url)
         honeymap_url = raw_input('Honeymap url ["{}"]: '.format(default_honeymap_url))
         if honeymap_url.endswith('/'):
             honeymap_url = honeymap_url[:-1]
@@ -148,7 +150,6 @@ def generate_config():
 
         log_file_path = raw_input('Path for log file ["{}"]: '.format(default_log_path))
 
-    server_base_url = server_base_url if server_base_url.strip() else default_base_url
     honeymap_url = honeymap_url if honeymap_url.strip() else default_honeymap_url
     log_file_path = log_file_path if log_file_path else default_log_path
 


### PR DESCRIPTION
honeymap_url displays [:3000] and therefore computes the wrong configuration if default is accepted.