### PR TITLE
Update deploy_cowrie.sh

### DIFF
--- a/scripts/deploy_cowrie.sh
+++ b/scripts/deploy_cowrie.sh
@@ -47,6 +47,7 @@ pip install -r requirements.txt
 cp cowrie.cfg.dist cowrie.cfg
 sed -i 's/hostname = svr04/hostname = server/g' cowrie.cfg
 sed -i 's/#listen_port = 2222/listen_port = 22/g' cowrie.cfg
+sed -i 's/listen_endpoints = tcp:2222:interface=0.0.0.0/listen_endpoints = tcp:22:interface=0.0.0.0/g' cowrie.cfg
 sed -i 's/ssh_version_string = SSH-2.0-OpenSSH_6.0p1 Debian-4+deb7u2/ssh_version_string = SSH-2.0-OpenSSH_6.7p1 Ubuntu-5ubuntu1.3/g' cowrie.cfg
 sed -i 's/#\[output_hpfeeds\]/[output_hpfeeds]/g' cowrie.cfg
 sed -i "s/#server = hpfeeds.mysite.org/server = $HPF_HOST/g" cowrie.cfg


### PR DESCRIPTION
I have noticed that this script no longer works since the last cowrie update . 
This is due to two things : 

- env has changed to cowrie-env
- initialization script start.sh is deprecated and substituted by bin/cowrie start

After making these changes I was able to deploy cowrie without issues on Ubuntu 14