### PR TITLE
Fixes #441

### DIFF
--- a/scripts/deploy_shockpot.sh
+++ b/scripts/deploy_shockpot.sh
@@ -17,7 +17,7 @@ chmod 755 registration.sh
 . ./registration.sh $server_url $deploy_key "shockpot"
 
 apt-get update
-apt-get -y install git python-pip supervisor
+apt-get -y install git python python-pip supervisor
 pip install virtualenv
 
 # Get the Shockpot source

--- a/scripts/deploy_wordpot.sh
+++ b/scripts/deploy_wordpot.sh
@@ -17,7 +17,7 @@ chmod 755 registration.sh
 . ./registration.sh $server_url $deploy_key "wordpot"
 
 apt-get update
-apt-get -y install git python-pip supervisor
+apt-get -y install git python python-pip supervisor
 pip install virtualenv
 
 # Get the Wordpot source

--- a/scripts/install_honeymap.sh
+++ b/scripts/install_honeymap.sh
@@ -40,9 +40,9 @@ fi
 # Install a decent version of golang
 if [ "$(uname -m)" == "x86_64" ] ;
 then
-    GO_PACKAGE="go1.4.2.linux-amd64.tar.gz"
+    GO_PACKAGE="go1.9.linux-amd64.tar.gz"
 else
-    GO_PACKAGE="go1.4.2.linux-386.tar.gz"
+    GO_PACKAGE="go1.9.linux-386.tar.gz"
 fi
 
 cd /usr/local/

--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -65,7 +65,7 @@ $VIRTUALENV -p $PYTHON env
 . env/bin/activate
 
 pip install cffi
-pip install pyopenssl>=0.16
+pip install pyopenssl==17.3.0
 pip install pymongo
 pip install -e git+https://github.com/rep/evnet.git#egg=evnet-dev
 pip install .

--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -65,7 +65,7 @@ $VIRTUALENV -p $PYTHON env
 . env/bin/activate
 
 pip install cffi
-pip install pyopenssl==0.14
+pip install pyopenssl>=0.16
 pip install pymongo
 pip install -e git+https://github.com/rep/evnet.git#egg=evnet-dev
 pip install .


### PR DESCRIPTION
Also updates wordpot and shockpot deploy scripts to install python, required for Ubuntu 16.04 where python isn't installed from base install.

Lastly, also update install script for honeymap to use latest Go version, 1.9.