### PR TITLE
Fix amun install script to use master branch

### DIFF
--- a/scripts/deploy_amun.sh
+++ b/scripts/deploy_amun.sh
@@ -25,9 +25,6 @@ apt-get -y install git python-pip supervisor
 cd /opt
 git clone https://github.com/zeroq/amun.git
 cd amun
-# Currently only the development branch supports hpfeeds
-git checkout development
-mkdir hexdumps
 AMUN_HOME=/opt/amun 
 
 # Configure Amun (disable vuln-http, too many false alarms here)


### PR DESCRIPTION
Previously it would checkout the dev branch of amun and do some tweaking. Changing branches is no longer needed and the 'hexdumps' directory already exists.