### PR TITLE
Enable mongodb on start for Ubuntu

### DIFF
--- a/scripts/install_mongo.sh
+++ b/scripts/install_mongo.sh
@@ -27,6 +27,7 @@ EOF
 
         systemctl start mongodb
         systemctl status mongodb
+        systemctl enable mongodb
 
     else
         apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10


### PR DESCRIPTION
Allows MHN to be running on reboot.