### PR TITLE
Pull evnet from the threatstream fork

### DIFF
--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -67,7 +67,7 @@ $VIRTUALENV -p $PYTHON env
 pip install cffi
 pip install pyopenssl==17.3.0
 pip install pymongo
-pip install -e git+https://github.com/rep/evnet.git#egg=evnet-dev
+pip install -e git+https://github.com/threatstream/evnet.git#egg=evnet-dev
 pip install .
 deactivate
 


### PR DESCRIPTION
Fixes error "urllib2.HTTPError: HTTP Error 403: Forbidden" caused by using HTTP
instead of HTTPS