### PR TITLE
Update hpfeeds-logger to version 0.7.3

### DIFF
--- a/scripts/install_hpfeeds-logger-arcsight.sh
+++ b/scripts/install_hpfeeds-logger-arcsight.sh
@@ -14,7 +14,7 @@ then
     cd /opt/
     virtualenv hpfeeds-logger
     . hpfeeds-logger/bin/activate
-    pip install hpfeeds-logger==0.0.7.2
+    pip install hpfeeds-logger==0.0.7.3
 else
     echo "It looks like hpfeeds-logger is already installed. Moving on to configuration."
 fi

--- a/scripts/install_hpfeeds-logger-json.sh
+++ b/scripts/install_hpfeeds-logger-json.sh
@@ -14,7 +14,7 @@ then
     cd /opt/
     virtualenv hpfeeds-logger
     . hpfeeds-logger/bin/activate
-    pip install hpfeeds-logger==0.0.7.2
+    pip install hpfeeds-logger==0.0.7.3
 else
     echo "It looks like hpfeeds-logger is already installed. Moving on to configuration."
 fi

--- a/scripts/install_hpfeeds-logger-splunk.sh
+++ b/scripts/install_hpfeeds-logger-splunk.sh
@@ -14,7 +14,7 @@ then
     cd /opt/
     virtualenv hpfeeds-logger
     . hpfeeds-logger/bin/activate
-    pip install hpfeeds-logger==0.0.7.2
+    pip install hpfeeds-logger==0.0.7.3
 else
     echo "It looks like hpfeeds-logger is already installed. Moving on to configuration."
 fi


### PR DESCRIPTION
Version 0.7.2 is no longer installable due to using HTTP rather than HTTPS