### PR TITLE
Move sensor registration to after sensor install completes

### DIFF
--- a/scripts/deploy_amun.sh
+++ b/scripts/deploy_amun.sh
@@ -13,11 +13,6 @@ fi
 server_url=$1
 deploy_key=$2
 
-wget $server_url/static/registration.txt -O registration.sh
-chmod 755 registration.sh
-# Note: this will export the HPF_* variables
-. ./registration.sh $server_url $deploy_key "amun"
-
 apt-get update
 apt-get -y install git python-pip supervisor
 
@@ -36,6 +31,12 @@ sed -i $'s/log_modules:/log_modules:\\\n    log-hpfeeds/g' conf/amun.conf
 echo "104854" > /proc/sys/fs/file-max
 ulimit -Hn 104854
 ulimit -n 104854
+
+# Register the sensor with the MHN server.
+wget $server_url/static/registration.txt -O registration.sh
+chmod 755 registration.sh
+# Note: this will export the HPF_* variables
+. ./registration.sh $server_url $deploy_key "amun"
 
 # Setup HPFeeds
 cat > /opt/amun/conf/log-hpfeeds.conf <<EOF

--- a/scripts/deploy_conpot.sh
+++ b/scripts/deploy_conpot.sh
@@ -10,11 +10,6 @@ fi
 server_url=$1
 deploy_key=$2
 
-wget $server_url/static/registration.txt -O registration.sh
-chmod 755 registration.sh
-# Note: this will export the HPF_* variables
-. ./registration.sh $server_url $deploy_key "conpot"
-
 echo "deb http://en.archive.ubuntu.com/ubuntu precise main multiverse" | sudo tee -a /etc/apt/sources.list
 apt-get update
 apt-get install -y git libmysqlclient-dev libsmi2ldbl snmp-mibs-downloader python-dev libevent-dev libxslt1-dev libxml2-dev python-pip python-mysqldb pkg-config libvirt-dev supervisor
@@ -31,6 +26,12 @@ pip install -U setuptools
 pip install -e git+https://github.com/threatstream/hpfeeds.git#egg=hpfeeds-dev
 pip install -e git+https://github.com/mushorg/conpot.git#egg=conpot-dev
 pip install -e git+https://github.com/mushorg/modbus-tk.git#egg=modbus-tk
+
+# Register sensor with MHN server.
+wget $server_url/static/registration.txt -O registration.sh
+chmod 755 registration.sh
+# Note: this will export the HPF_* variables
+. ./registration.sh $server_url $deploy_key "conpot"
 
 cat > conpot.cfg <<EOF
 [common]

--- a/scripts/deploy_cowrie.sh
+++ b/scripts/deploy_cowrie.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# tested on AWS: Ubuntu 14.04.5 LTS
-# 
-
 set -e
 set -x
 
@@ -18,11 +15,6 @@ apt-get install -y python
 
 server_url=$1
 deploy_key=$2
-
-wget $server_url/static/registration.txt -O registration.sh
-chmod 755 registration.sh
-# Note: this will export the HPF_* variables
-. ./registration.sh $server_url $deploy_key "cowrie"
 
 apt-get update
 apt-get -y install python-dev git supervisor authbind openssl python-virtualenv build-essential python-gmpy2 libgmp-dev libmpfr-dev libmpc-dev libssl-dev python-pip libffi-dev
@@ -43,6 +35,12 @@ source cowrie-env/bin/activate
 # Could not find a version that satisfies the requirement csirtgsdk (from -r requirements.txt (line 10)) (from versions: 0.0.0a5, 0.0.0a6, 0.0.0a5.linux-x86_64, 0.0.0a6.linux-x86_64, 0.0.0a3)
 pip install csirtgsdk==0.0.0a6
 pip install -r requirements.txt 
+
+# Register sensor with MHN server.
+wget $server_url/static/registration.txt -O registration.sh
+chmod 755 registration.sh
+# Note: this will export the HPF_* variables
+. ./registration.sh $server_url $deploy_key "cowrie"
 
 cp cowrie.cfg.dist cowrie.cfg
 sed -i 's/hostname = svr04/hostname = server/g' cowrie.cfg

--- a/scripts/deploy_dionaea.sh
+++ b/scripts/deploy_dionaea.sh
@@ -13,11 +13,6 @@ fi
 server_url=$1
 deploy_key=$2
 
-wget $server_url/static/registration.txt -O registration.sh
-chmod 755 registration.sh
-# Note: this will export the HPF_* variables
-. ./registration.sh $server_url $deploy_key "dionaea"
-
 if [ -f /etc/redhat-release ]; then
     export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:$PATH
     yum -y update
@@ -48,6 +43,12 @@ EOF
     #fixme
     chmod -R a+wrx /var/dionaea
     docker pull threatstream/dionaea-mhn
+
+    # Register the sensor with MHN server.
+    wget $server_url/static/registration.txt -O registration.sh
+    chmod 755 registration.sh
+    # Note: this will export the HPF_* variables
+    . ./registration.sh $server_url $deploy_key "dionaea"
 
     echo "Getting dionea from $server_url"
     curl $server_url/static/dionaea.conf | sed -e "s/HPF_HOST/$HPF_HOST/" | sed -e "s/HPF_PORT/$HPF_PORT/" | sed -e "s/HPF_IDENT/$HPF_IDENT/" | sed -e "s/HPF_SECRET/$HPF_SECRET/" > /etc/dionaea/dionaea.conf
@@ -83,7 +84,11 @@ elif [ -f /etc/debian_version ]; then
             apt-get install -y dionaea supervisor patch
     fi
 
-
+    # Register the sensor with MHN server.
+    wget $server_url/static/registration.txt -O registration.sh
+    chmod 755 registration.sh
+    # Note: this will export the HPF_* variables
+    . ./registration.sh $server_url $deploy_key "dionaea"
 
     cp /etc/dionaea/dionaea.conf.dist /etc/dionaea/dionaea.conf
 cat > /tmp/dionaea.hpfeeds.patch <<EOF

--- a/scripts/deploy_elastichoney.sh
+++ b/scripts/deploy_elastichoney.sh
@@ -11,11 +11,6 @@ fi
 server_url=$1
 deploy_key=$2
 
-wget $server_url/static/registration.txt -O registration.sh
-chmod 755 registration.sh
-# Note: this will export the HPF_* variables
-. ./registration.sh $server_url $deploy_key "elastichoney"
-
 apt-get update
 apt-get -y install git golang supervisor
 
@@ -28,6 +23,12 @@ cd elastichoney
 export GOPATH=/opt/elastichoney
 go get || true
 go build
+
+# Register the sensor with the MHN server.
+wget $server_url/static/registration.txt -O registration.sh
+chmod 755 registration.sh
+# Note: this will export the HPF_* variables
+. ./registration.sh $server_url $deploy_key "elastichoney"
 
 cat > config.json<<EOF
 {

--- a/scripts/deploy_glastopf.sh
+++ b/scripts/deploy_glastopf.sh
@@ -25,11 +25,6 @@ server_url=$1
 deploy_key=$2
 GLASTOPF_HOME=/opt/glastopf
 
-wget $server_url/static/registration.txt -O registration.sh
-chmod 0755 registration.sh
-# Note: This will export the HPF_* variables
-. ./registration.sh $server_url $deploy_key "glastopf"
-
 # Update repository
 apt-get update
 
@@ -73,6 +68,12 @@ pip uninstall --yes setuptools
 git clone https://github.com/mushorg/glastopf.git $GLASTOPF_HOME
 cd $GLASTOPF_HOME
 python setup.py install
+
+# Register the sensor with the MHN server.
+wget $server_url/static/registration.txt -O registration.sh
+chmod 0755 registration.sh
+# Note: This will export the HPF_* variables
+. ./registration.sh $server_url $deploy_key "glastopf"
 
 # Add the modified glastopf.cfg
 cat > $GLASTOPF_HOME/glastopf.cfg <<EOF

--- a/scripts/deploy_p0f.sh
+++ b/scripts/deploy_p0f.sh
@@ -13,11 +13,6 @@ fi
 server_url=$1
 deploy_key=$2
 
-wget $server_url/static/registration.txt -O registration.sh
-chmod 755 registration.sh
-# Note: this will export the HPF_* variables
-. ./registration.sh $server_url $deploy_key "p0f"
-
 apt-get update
 apt-get -y install git supervisor libpcap-dev libjansson-dev gcc
 
@@ -29,6 +24,12 @@ git checkout origin/hpfeeds
 ./build.sh
 useradd -d /var/empty/p0f -M -r -s /bin/nologin p0f-user || true
 mkdir -p -m 755 /var/empty/p0f
+
+# Register the sensor with the MHN server.
+wget $server_url/static/registration.txt -O registration.sh
+chmod 755 registration.sh
+# Note: this will export the HPF_* variables
+. ./registration.sh $server_url $deploy_key "p0f"
 
 cat > /etc/supervisor/conf.d/p0f.conf <<EOF
 [program:p0f]

--- a/scripts/deploy_shockpot.sh
+++ b/scripts/deploy_shockpot.sh
@@ -11,11 +11,6 @@ fi
 server_url=$1
 deploy_key=$2
 
-wget $server_url/static/registration.txt -O registration.sh
-chmod 755 registration.sh
-# Note: this will export the HPF_* variables
-. ./registration.sh $server_url $deploy_key "shockpot"
-
 apt-get update
 apt-get -y install git python-pip supervisor
 pip install virtualenv
@@ -28,6 +23,12 @@ cd shockpot
 virtualenv env
 . env/bin/activate
 pip install -r requirements.txt
+
+# Register sensor with MHN server.
+wget $server_url/static/registration.txt -O registration.sh
+chmod 755 registration.sh
+# Note: this will export the HPF_* variables
+. ./registration.sh $server_url $deploy_key "shockpot"
 
 cat > shockpot.conf<<EOF
 [server]

--- a/scripts/deploy_snort.sh
+++ b/scripts/deploy_snort.sh
@@ -15,11 +15,6 @@ fi
 server_url=$1
 deploy_key=$2
 
-wget $server_url/static/registration.txt -O registration.sh
-chmod 755 registration.sh
-# Note: this will export the HPF_* variables
-. ./registration.sh $server_url $deploy_key "snort"
- 
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential libpcap-dev libjansson-dev libpcre3-dev libdnet-dev libdumbnet-dev libdaq-dev flex bison python-pip git make automake libtool zlib1g-dev
 
@@ -49,6 +44,12 @@ git clone -b hpfeeds-support https://github.com/threatstream/snort.git
 export CPPFLAGS=-I/include
 cd snort
 ./configure --prefix=/opt/snort && make && make install 
+
+# Register the sensor with the MHN server.
+wget $server_url/static/registration.txt -O registration.sh
+chmod 755 registration.sh
+# Note: this will export the HPF_* variables
+. ./registration.sh $server_url $deploy_key "snort"
 
 mkdir -p /opt/snort/etc /opt/snort/rules /opt/snort/lib/snort_dynamicrules /opt/snort/lib/snort_dynamicpreprocessor /var/log/snort/
 cd etc

--- a/scripts/deploy_suricata.sh
+++ b/scripts/deploy_suricata.sh
@@ -19,11 +19,6 @@ fi
 server_url=$1
 deploy_key=$2
 
-wget $server_url/static/registration.txt -O registration.sh
-chmod 755 registration.sh
-# Note: this will export the HPF_* variables
-. ./registration.sh $server_url $deploy_key "suricata"
- 
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential libpcap-dev libjansson-dev libpcre3-dev libdnet-dev libdumbnet-dev libdaq-dev flex bison python-pip git make automake libtool zlib1g-dev python-dev libnetfilter-queue-dev libnetfilter-queue1 libnfnetlink-dev libnfnetlink0 libyaml-dev libmagic-dev autoconf libpcre3 libpcre3-dbg libnet1-dev libyaml-0-2 pkg-config zlib1g libcap-ng-dev libcap-ng0
 
@@ -68,6 +63,12 @@ export CPPFLAGS=-I/include
 make
 make install-full
 
+# Register the sensor with MHN server.
+wget $server_url/static/registration.txt -O registration.sh
+chmod 755 registration.sh
+# Note: this will export the HPF_* variables
+. ./registration.sh $server_url $deploy_key "suricata"
+ 
 cd /opt/suricata/etc/suricata
 #sed -i -r "/\s*- alert-hpfeeds/,/\s*reconnect: yes # do we reconnect if publish fails/d" suricata.yaml
 #sed -i -r "s/^  # hpfeeds output/ # hpfeeds output\n  - alert-hpfeeds:\n      enabled: yes\n      host: $HPF_HOST\n      ident: $HPF_IDENT\n      secret: $HPF_SECRET\n      channel: suricata.events\n      reconnect: yes # do we reconnect if publish fails ?!\n/" suricata.yaml

--- a/scripts/deploy_wordpot.sh
+++ b/scripts/deploy_wordpot.sh
@@ -11,11 +11,6 @@ fi
 server_url=$1
 deploy_key=$2
 
-wget $server_url/static/registration.txt -O registration.sh
-chmod 755 registration.sh
-# Note: this will export the HPF_* variables
-. ./registration.sh $server_url $deploy_key "wordpot"
-
 apt-get update
 apt-get -y install git python-pip supervisor
 pip install virtualenv
@@ -32,6 +27,12 @@ pip install -r requirements.txt
 cp wordpot.conf wordpot.conf.bak
 sed -i '/HPFEEDS_.*/d' wordpot.conf
 sed -i "s/^HOST\s.*/HOST = '0.0.0.0'/" wordpot.conf
+
+# Register the sensor with the MHN server.
+wget $server_url/static/registration.txt -O registration.sh
+chmod 755 registration.sh
+# Note: this will export the HPF_* variables
+. ./registration.sh $server_url $deploy_key "wordpot"
 
 cat >> wordpot.conf <<EOF
 HPFEEDS_ENABLED = True
@@ -54,12 +55,5 @@ autorestart=true
 redirect_stderr=true
 stopsignal=QUIT
 EOF
-
-# Quick check to see if on Ubuntu using systemd or init
-if [ -n "`which service`" ]; then
-    service supervisor start
-elif [ -n "`which systemctl`" ]; then
-    systemctl start supervisor
-fi
 
 supervisorctl update

--- a/server/mhn/__init__.py
+++ b/server/mhn/__init__.py
@@ -136,28 +136,28 @@ def create_clean_db():
         #|-- deploy_dionaea.sh
         #|-- deploy_snort.sh
         #|-- deploy_kippo.sh
-        deployscripts = {
-            'Ubuntu - Conpot': path.abspath('../scripts/deploy_conpot.sh'),
-            'Ubuntu - Dionaea': path.abspath('../scripts/deploy_dionaea.sh'),
-            'Ubuntu - Snort': path.abspath('../scripts/deploy_snort.sh'),
-            'Ubuntu - cowrie': path.abspath('../scripts/deploy_cowrie.sh'),
-            'Ubuntu/Raspberry Pi - Kippo': path.abspath('../scripts/deploy_kippo.sh'),
-            'Ubuntu - Amun': path.abspath('../scripts/deploy_amun.sh'),
-            'Ubuntu - Glastopf': path.abspath('../scripts/deploy_glastopf.sh'),
-            'Ubuntu - Wordpot': path.abspath('../scripts/deploy_wordpot.sh'),
-            'Ubuntu - Shockpot': path.abspath('../scripts/deploy_shockpot.sh'),
-            'Ubuntu - p0f': path.abspath('../scripts/deploy_p0f.sh'),
-            'Ubuntu - Suricata': path.abspath('../scripts/deploy_suricata.sh'),
-            'Ubuntu - ElasticHoney': path.abspath('../scripts/deploy_elastichoney.sh'),
-            'Raspberry Pi - Dionaea': path.abspath('../scripts/deploy_raspberrypi.sh'),
-            'Ubuntu - Dionaea with HTTP': path.abspath('../scripts/deploy_dionaea_http.sh'),
-            'Ubuntu - Kippo as vulnerable Juniper Netscreen': path.abspath('../scripts/deploy_kippo_as_juniper.sh'),
-            'Ubuntu - Shockpot Sinkhole': path.abspath('../scripts/deploy_shockpot_sinkhole.sh'),
-            'Redhat/Centos - Kippo': path.abspath('../scripts/deploy_kippo-centos.sh'),
-        }
-        for honeypot, deploypath in deployscripts.iteritems():
+        deployscripts = [
+            ['Ubuntu - Conpot', '../scripts/deploy_conpot.sh'],
+            ['Ubuntu - Dionaea', '../scripts/deploy_dionaea.sh'],
+            ['Ubuntu - Snort', '../scripts/deploy_snort.sh'],
+            ['Ubuntu - cowrie', '../scripts/deploy_cowrie.sh'],
+            ['Ubuntu/Raspberry Pi - Kippo', '../scripts/deploy_kippo.sh'],
+            ['Ubuntu - Amun', '../scripts/deploy_amun.sh'],
+            ['Ubuntu - Glastopf', '../scripts/deploy_glastopf.sh'],
+            ['Ubuntu - Wordpot', '../scripts/deploy_wordpot.sh'],
+            ['Ubuntu - Shockpot', '../scripts/deploy_shockpot.sh'],
+            ['Ubuntu - p0f', '../scripts/deploy_p0f.sh'],
+            ['Ubuntu - Suricata', '../scripts/deploy_suricata.sh'],
+            ['Ubuntu - ElasticHoney', '../scripts/deploy_elastichoney.sh'],
+            ['Raspberry Pi - Dionaea', '../scripts/deploy_raspberrypi.sh'],
+            ['Ubuntu - Dionaea with HTTP', '../scripts/deploy_dionaea_http.sh'],
+            ['Ubuntu - Kippo as vulnerable Juniper Netscreen', '../scripts/deploy_kippo_as_juniper.sh'],
+            ['Ubuntu - Shockpot Sinkhole', '../scripts/deploy_shockpot_sinkhole.sh'],
+            ['Redhat/Centos - Kippo', '../scripts/deploy_kippo-centos.sh'],
+        ]
+        for honeypot, deploypath in deployscripts:
 
-            with open(deploypath, 'r') as deployfile:
+            with open(path.abspath(deploypath), 'r') as deployfile:
                 initdeploy = DeployScript()
                 initdeploy.script = deployfile.read()
                 initdeploy.notes = 'Initial deploy script for {}'.format(honeypot)


### PR DESCRIPTION
This prevents sensors from being registered on the server before their install completes. In many cases, an install might fail for various reasons yet the sensor is prematurely registered, clogging up the MHN server's list of running sensors with false entries.

Fixes #188 