### PR TITLE
updated hpfeeds-threatstream==1.0

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -15,7 +15,7 @@ requests==2.4.3
 xmltodict==0.9.0
 uWSGI==2.0.14
 pymongo==2.7.2
-hpfeeds-threatstream==1.0
+hpfeeds-threatstream==1.1
 pygal==1.7.0
 hpfeeds-logger==0.0.7.3
 GeoIP==1.3.2


### PR DESCRIPTION
hpfeeds-logger 0.0.7.3 has requirement hpfeeds-threatstream==1.1, but you'll have hpfeeds-threatstream 1.0 which is incompatible.