### PR TITLE
Only add mongo keyserver for Ubuntu < 18

### DIFF
--- a/scripts/install_mongo.sh
+++ b/scripts/install_mongo.sh
@@ -5,12 +5,18 @@ set -x
 
 if [ -f /etc/debian_version ]; then
 
-    if [ "$(lsb_release -r -s)" == "16.04" ] || [ "$(lsb_release -r -s)" == "17.04" ]; then
-
-        apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
-        echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+    if [ "$(lsb_release -r -s)" == "14.04" ] || [ "$(lsb_release -r -s)" == "15.04" ]; then
+        apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+        echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list
         apt-get update
         apt-get install -y mongodb-org
+    else
+        if [ "$(lsb_release -r -s)" == "16.04" ] || [ "$(lsb_release -r -s)" == "17.04" ]; then
+            apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
+            echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+        fi
+        apt-get update
+        apt-get install -y mongodb
 
         cat > /etc/systemd/system/mongodb.service <<EOF
 [Unit]
@@ -29,11 +35,7 @@ EOF
         systemctl status mongodb
         systemctl enable mongodb
 
-    else
-        apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-        echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list
-        apt-get update
-        apt-get install -y mongodb-org
+
     fi
 
 elif [ -f /etc/redhat-release ]; then


### PR DESCRIPTION
Leave 14 and 16 install the same but add conditions so that under ubuntu 18 we don't muck with mongo keyserver stuff.