### PR TITLE
Mongodb fix for Ubuntu 18

### DIFF
--- a/server/mhn/common/clio.py
+++ b/server/mhn/common/clio.py
@@ -301,16 +301,9 @@ class Session(ResourceMixin):
             }
         ]
 
-        res = self.collection.aggregate(query)
-        def format_result(r):
-            result = dict(r['_id'])
-            result['count'] = r['count']
-            return result
+        result = self.collection.aggregate(query)
+        return list(result)
 
-        if 'ok' in res:
-            return [
-                format_result(r) for r in res.get('result', [])[:top]
-            ]
 
     def top_attackers(self, top=5, hours_ago=None):
         return self._tops('source_ip', top, hours_ago)

--- a/server/mhn/common/clio.py
+++ b/server/mhn/common/clio.py
@@ -302,7 +302,15 @@ class Session(ResourceMixin):
         ]
 
         result = self.collection.aggregate(query)
-        return list(result)
+        res = list(result)
+	def format_result(r):
+            result = dict(r['_id'])
+            result['count'] = r['count']
+            return result
+
+        return [
+            format_result(r) for r in res[:top]
+        ]
 
 
     def top_attackers(self, top=5, hours_ago=None):

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -14,7 +14,7 @@ redis==2.10.3
 requests==2.4.3
 xmltodict==0.9.0
 uWSGI==2.0.17.1
-pymongo==2.7.2
+pymongo==3.7.2
 hpfeeds-threatstream==1.0
 pygal==1.7.0
 hpfeeds-logger==0.0.7.3


### PR DESCRIPTION
This fixes the Ubuntu 18 install. Pymongo python library has been updated across all platforms. Minimal testing has been done but it could definitely use more.