### PR TITLE
java 11 for elk install

### DIFF
--- a/scripts/install_elk_raw_hpfeeds.sh
+++ b/scripts/install_elk_raw_hpfeeds.sh
@@ -4,10 +4,10 @@ set -x
 set -e
 
 # install Java
-apt-get install -y python-software-properties
-add-apt-repository -y ppa:webupd8team/java
+apt-get install -y software-properties-common
+add-apt-repository -y ppa:linuxuprising/java
 apt-get update
-apt-get -y install oracle-java8-installer
+apt-get install -y oracle-java11-installer
 
 # Install ES
 wget -O - http://packages.elasticsearch.org/GPG-KEY-elasticsearch |  apt-key add -


### PR DESCRIPTION
Java was updated and 8 was removed from the repo.

Currently testing it, but here's the article I followed: https://www.linuxuprising.com/2018/10/how-to-install-oracle-java-11-in-ubuntu.html

Thank you!